### PR TITLE
patch 1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
-
+    tags: ["*"]
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          - go-version: ^1.17
+          go-version: ^1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v2
+        with:
+          - go-version: ^1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v2
+        with:
+          - go-version: ^1.17
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Set up Go 1.x
+      - name: Set up Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ^1.13
-        id: go
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          - go-version: ^1.17
+          go-version: ^1.17
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2


### PR DESCRIPTION
- fix go versions in actions
- use newer go version
- not an array
- only release on tags
