### PR TITLE
Support Windows

### DIFF
--- a/pkg/iexec/iexec.go
+++ b/pkg/iexec/iexec.go
@@ -2,8 +2,9 @@ package iexec
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
+
+	"github.com/pkg/errors"
 
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
@@ -177,19 +178,21 @@ func exec(restCfg *rest.Config, pod corev1.Pod, container corev1.Container, cmd 
 		return errors.Wrap(err, "unable to execute remote command")
 	}
 
+	fd := int(os.Stdin.Fd())
+
 	// Put the terminal into raw mode to prevent it echoing characters twice.
-	oldState, err := term.MakeRaw(0)
+	oldState, err := term.MakeRaw(fd)
 	if err != nil {
 		return errors.Wrap(err, "unable to init terminal")
 	}
 
-	termWidth, termHeight, _ := term.GetSize(0)
+	termWidth, termHeight, _ := term.GetSize(fd)
 	termSize := remotecommand.TerminalSize{Width: uint16(termWidth), Height: uint16(termHeight)}
 	s := make(sizeQueue, 1)
 	s <- termSize
 
 	defer func() {
-		err := term.Restore(0, oldState)
+		err := term.Restore(fd, oldState)
 		if err != nil {
 			log.Error(err)
 		}


### PR DESCRIPTION
Current implementation use 0 for file descriptor of stdin. So Windows fail.
```
time="2021-11-19T11:45:04+09:00" level=fatal msg="unable to init terminal: The handle is invalid."
Error: exit status 1
```
This change fix to use `os.Stdin.Fd()`.

![image](https://user-images.githubusercontent.com/10111/142556558-8a58808e-b152-42e9-bafd-3eb7379598d1.png)

