### PR TITLE
feat: Support label selector

### DIFF
--- a/pkg/cmd/iexec.go
+++ b/pkg/cmd/iexec.go
@@ -50,6 +50,7 @@ type IExecOptions struct {
 	containerFilter string
 	lvl             string
 	namespace       string
+	labelSelector   string
 	naked           bool
 	vimMode         bool
 
@@ -89,7 +90,8 @@ func NewCmdIExec(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", o.allNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	cmd.PersistentFlags().StringVarP(&o.containerFilter, "container", "c", "", "Container to search")
-	cmd.PersistentFlags().StringVarP(&o.lvl, "log-level", "l", "", "log level (trace|debug|info|warn|error|fatal|panic)")
+	cmd.PersistentFlags().StringVarP(&o.lvl, "log-level", "", "", "log level (trace|debug|info|warn|error|fatal|panic)")
+	cmd.PersistentFlags().StringVarP(&o.labelSelector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.PersistentFlags().BoolVarP(&o.vimMode, "vim-mode", "v", false, "Vim Mode enabled")
 	cmd.PersistentFlags().BoolVarP(&o.naked, "naked", "x", false, "Decolorize output")
 	o.configFlags.AddFlags(cmd.Flags())
@@ -160,6 +162,7 @@ func (o *IExecOptions) Run(args []string) error {
 
 	config := &iexec.Config{
 		Namespace:       o.namespace,
+		LabelSelector:   o.labelSelector,
 		Naked:           o.naked,
 		VimMode:         o.vimMode,
 		PodFilter:       podFilter,

--- a/pkg/iexec/iexec.go
+++ b/pkg/iexec/iexec.go
@@ -27,6 +27,7 @@ type Iexecer interface {
 
 type Config struct {
 	Namespace       string
+	LabelSelector   string
 	Naked           bool
 	VimMode         bool
 	PodFilter       string
@@ -47,6 +48,7 @@ func NewIexec(restConfig *rest.Config, config *Config) *Iexec {
 		"Vim Mode":        config.VimMode,
 		"Naked":           config.Naked,
 		"Namespace":       config.Namespace,
+		"LabelSelector":   config.LabelSelector,
 	}).Debug("iexec config values...")
 
 	return &Iexec{restConfig: restConfig, config: config}
@@ -110,7 +112,7 @@ func (r *Iexec) Do() error {
 		return errors.Wrap(err, "unable to get kubernetes for config")
 	}
 
-	pods, err := getAllPods(client, r.config.Namespace)
+	pods, err := getAllPods(client, r.config.Namespace, r.config.LabelSelector)
 	if err != nil {
 		return err
 	}

--- a/pkg/iexec/kubernetes.go
+++ b/pkg/iexec/kubernetes.go
@@ -15,8 +15,8 @@ import (
 )
 
 // get all pods from kubernetes API.
-func getAllPods(client kubernetes.Interface, namespace string) (*corev1.PodList, error) {
-	pods, err := client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase=Running"})
+func getAllPods(client kubernetes.Interface, namespace, selector string) (*corev1.PodList, error) {
+	pods, err := client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase=Running", LabelSelector: selector})
 	if err != nil {
 		return pods, errors.Wrap(err, "unable to get pods")
 	}


### PR DESCRIPTION
`--selector` | `-l` to select pods with matching labels

BREAKING CHANGE: `-l` is no longer used for log level